### PR TITLE
feat: format values with nix formatter, if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,15 @@ lowest priority, and only if they exist):
 ### Config Schema
 
 ```toml
-min_score = 1 # min score required for search matches
-debounce_time = 25 # debounce time for search, in ms
-default_scope = "" # default scope to use if not specified on the command line
+# Minimum score required for search matches
+min_score = 1
+# Debounce time for search, in ms
+debounce_time = 25
+# Default scope to use if not specified on the command line
+default_scope = ""
+# Formatter command to use for evaluated values, if available. Takes input on
+# stdin and outputs the formatted code back to stdout.
+formatter_cmd = "nixfmt"
 
 [scopes.<name>]
 # Description text, for command-line completion
@@ -302,14 +308,13 @@ jq '[to_entries[] | .value.name = .key | .value.declarations = [.value.declarati
 evaluator = "nix eval /path/to/flake#nixosConfigurations.JaMarcus.config.home-manager.users.varun.{{ .Option }}"
 ```
 
-
 ### flake-parts
 
 Flake-parts configurations likely need to be defined on a per-flake basis.
 
-It can be useful to configure a repository-specific `optnix.toml` and have
-a `options-search` Nix app wrapper around `optnix`, in order to prevent
-excessive command-line parameter specifications.
+It can be useful to configure a repository-specific `optnix.toml` and have a
+`options-search` Nix app wrapper around `optnix`, in order to prevent excessive
+command-line parameter specifications.
 
 Import the following flake module code to expose an options-doc directly inside
 the flake of choice to inspect options for:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -257,7 +257,7 @@ func getOptionListFromScope(log *logger.Logger, scopeName string, scope *config.
 	return nil, fmt.Errorf("no options found through all strategies for scope '%v'", scopeName)
 }
 
-func constructEvaluatorFromScope(s *config.Scope) (option.EvaluatorFunc, error) {
+func constructEvaluatorFromScope(formatterCmd string, s *config.Scope) (option.EvaluatorFunc, error) {
 	if s.EvaluatorCmd == "" {
 		return nil, nil
 	}
@@ -285,7 +285,13 @@ func constructEvaluatorFromScope(s *config.Scope) (option.EvaluatorFunc, error) 
 			}
 		}
 
-		value := strings.TrimSpace(cmdOutput.Stdout)
+		output := cmdOutput.Stdout
+
+		if formatterCmd != "" {
+			output, _ = option.FormatNixValue(formatterCmd, output)
+		}
+
+		value := strings.TrimSpace(output)
 
 		return value, nil
 	}, nil
@@ -324,7 +330,7 @@ func commandMain(cmd *cobra.Command, opts *CmdOptions) error {
 		return err
 	}
 
-	evaluator, err := constructEvaluatorFromScope(scope)
+	evaluator, err := constructEvaluatorFromScope(cfg.FormatterCmd, scope)
 	if err != nil {
 		log.Errorf("failed to construct evaluator: %v", err)
 		log.Warn("will not be able to evaluate values properly, still proceeding")

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
 github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	MinScore     int64  `koanf:"min_score"`
 	DebounceTime int64  `koanf:"debounce_time"`
 	DefaultScope string `koanf:"default_scope"`
+	FormatterCmd string `koanf:"formatter_cmd"`
 
 	Scopes map[string]Scope `koanf:"scopes"`
 }
@@ -31,6 +32,7 @@ func NewConfig() *Config {
 	return &Config{
 		MinScore:     1,
 		DebounceTime: 25,
+		FormatterCmd: "nixfmt",
 
 		Scopes: make(map[string]Scope),
 	}

--- a/option/option.go
+++ b/option/option.go
@@ -1,8 +1,14 @@
 package option
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
+	"os/exec"
+	"regexp"
+
+	"github.com/google/shlex"
 )
 
 type NixosOption struct {
@@ -41,4 +47,52 @@ func LoadOptions(r io.Reader) (NixosOptionSource, error) {
 	}
 
 	return options, nil
+}
+
+var (
+	elidedSetPattern  = regexp.MustCompile(`\{[ ]*\.\.\.[ ]*\}`)
+	elidedListPattern = regexp.MustCompile(`\[[ ]*\.\.\.[ ]*\]`)
+	angledPattern     = regexp.MustCompile(`«.*?»`)
+)
+
+func escapeNixEvalAnnotations(s string) string {
+	s = elidedSetPattern.ReplaceAllString(s, `"«elided set»"`)
+	s = elidedListPattern.ReplaceAllString(s, `"«elided list»"`)
+
+	s = angledPattern.ReplaceAllStringFunc(s, func(s string) string {
+		return fmt.Sprintf("%q", s)
+	})
+
+	return s
+}
+
+// Format a `nix-instantiate` or a `nix eval`-created string for pretty
+// printing using a Nix code formatter command.
+//
+// The command passed must take the Nix code from `stdin` and pass it back
+// out using `stdout`.
+func FormatNixValue(formatterCmd string, evaluatedValue string) (string, error) {
+	var stdin bytes.Buffer
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	stdin.WriteString(escapeNixEvalAnnotations(evaluatedValue))
+
+	argv, err := shlex.Split(formatterCmd)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := exec.Command(argv[0], argv[1:]...)
+
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Stdin = &stdin
+
+	err = cmd.Run()
+	if err != nil {
+		return "", err
+	}
+
+	return stdout.String(), nil
 }

--- a/package.nix
+++ b/package.nix
@@ -10,7 +10,7 @@ buildGoModule (finalAttrs: {
   version = "0.1.2";
   src = nix-gitignore.gitignoreSource [] ./.;
 
-  vendorHash = "sha256-UyAt7QyXxKosYuM0WiNStL1rgcBHy+2ThG5cgzw1rwY=";
+  vendorHash = "sha256-/rV21mX6VrJj39M6dBw4ubp6+O47hxeLn0ZcsG6Ujno=";
 
   nativeBuildInputs = [installShellFiles];
 


### PR DESCRIPTION
## What's Changed

If a Nix formatter is available, such as `nixfmt` or `alejandra`, use that to format Nix output.

This can be configured through `config.toml`, but uses `nixfmt` by default if it's available, since it wraps output to 100 columns by default, and is the official nixpkgs formatter.

`nix-instantiate` and `nix eval` both spit out invalid Nix code characters in some instances, so this is replaced with string qutoation in order to turn it into valid Nix code; however, this may not reflect the actual set options, so use at your own risk; this is meant to be a preview, rather than an actual option inspection.

Closes #2.