### PR TITLE
feat(nix): add optnix generator functions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
     inherit (nixpkgs) lib;
     eachSystem = lib.genAttrs lib.systems.flakeExposed;
   in {
-    lib = import ./nix/lib.nix {inherit lib;};
+    mkLib = import ./nix/lib.nix;
 
     packages = eachSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,8 @@
     inherit (nixpkgs) lib;
     eachSystem = lib.genAttrs lib.systems.flakeExposed;
   in {
+    lib = import ./nix/lib.nix {inherit lib;};
+
     packages = eachSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};
       inherit (pkgs) callPackage;

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,4 +1,6 @@
-{lib}: let
+pkgs: let
+  inherit (pkgs) lib;
+
   parsePath = pathStr: lib.splitString "." pathStr;
 
   removeNestedAttrs = paths: set: lib.foldl' (s: p: removeAtPath (parsePath p) s) set paths;
@@ -31,7 +33,6 @@
   */
   mkOptionsList = {
     options,
-    pkgs,
     transform ? lib.id,
     excluded ? [],
   }: let
@@ -51,10 +52,7 @@
   @param  modules   list of modules containing options
   @return           a derivation that builds an options.json file
   */
-  mkOptionsListFromModules = {
-    modules,
-    pkgs,
-  }: let
+  mkOptionsListFromModules = {modules}: let
     eval'd = lib.evalModules {
       modules =
         modules
@@ -64,7 +62,6 @@
     };
   in
     mkOptionsList {
-      inherit pkgs;
       inherit (eval'd) options;
     };
 
@@ -72,12 +69,16 @@
     /*
     Create an options list JSON file from a Home Manager source list of modules.
 
+    This code is based on the implementation found directly in Home Manager's
+    documentation generation, without using nixosOptionsDoc.
+
+    If an options attribute set is exposed, prefer using that over this.
+
     @param  home-manager  path to a home-manager source (like from a flake input or tarball)
     @param  modules       list of extra modules containing options to include
     @return               a derivation that builds an options.json file
     */
     mkOptionsListFromHMSource = {
-      pkgs,
       home-manager,
       modules ? [],
     }: let
@@ -130,7 +131,7 @@
         }).options;
     in
       mkOptionsList {
-        inherit options pkgs;
+        inherit options;
       };
   };
 in {

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -26,17 +26,19 @@
 
   @param  options   options attribute set to generate options list from
   @param  excluded  paths to options or sets of options to skip over
+  @param  transform function to apply to each option
   @return           a derivation that builds an options.json file
   */
   mkOptionsList = {
     options,
     pkgs,
+    transform ? lib.id,
     excluded ? [],
   }: let
     options' = removeAtPath excluded options;
 
     rawOptions =
-      lib.optionAttrSetToDocList options';
+      map transform (lib.optionAttrSetToDocList options');
     filteredOptions = lib.filter (opt: opt.visible && !opt.internal) rawOptions;
 
     optionsJSON = builtins.unsafeDiscardStringContext (builtins.toJSON filteredOptions);
@@ -44,7 +46,7 @@
     pkgs.writeText "options.json" optionsJSON;
 
   /*
-  Create an options list JSON string from a list of modules.
+  Create an options list JSON file from a list of modules.
 
   @param  modules   list of modules containing options
   @return           a derivation that builds an options.json file
@@ -65,11 +67,78 @@
       inherit pkgs;
       inherit (eval'd) options;
     };
+
+  hm = {
+    /*
+    Create an options list JSON file from a Home Manager source list of modules.
+
+    @param  home-manager  path to a home-manager source (like from a flake input or tarball)
+    @param  modules       list of extra modules containing options to include
+    @return               a derivation that builds an options.json file
+    */
+    mkOptionsListFromHMSource = {
+      pkgs,
+      home-manager,
+      modules ? [],
+    }: let
+      hmLib = import "${home-manager}/modules/lib/stdlib-extended.nix" lib;
+
+      hmModules = import "${home-manager}/modules/modules.nix" {
+        inherit pkgs;
+        lib = hmLib;
+        check = false;
+      };
+
+      scrubDerivations = prefixPath: attrs: let
+        scrubDerivation = name: value: let
+          pkgAttrName = prefixPath + "." + name;
+        in
+          if lib.isAttrs value
+          then
+            scrubDerivations pkgAttrName value
+            // lib.optionalAttrs (lib.isDerivation value) {
+              outPath = "\${${pkgAttrName}}";
+            }
+          else value;
+      in
+        lib.mapAttrs scrubDerivation attrs;
+
+      # Make sure the used package is scrubbed to avoid actually
+      # instantiating derivations.
+      scrubbedPkgsModule = {
+        imports = [
+          {
+            _module.args = {
+              pkgs = lib.mkForce (scrubDerivations "pkgs" pkgs);
+              pkgs_i686 = lib.mkForce {};
+            };
+          }
+        ];
+      };
+
+      allModules =
+        hmModules
+        ++ modules
+        ++ [
+          scrubbedPkgsModule
+        ];
+
+      options =
+        (hmLib.evalModules {
+          modules = allModules;
+          class = "homeManager";
+        }).options;
+    in
+      mkOptionsList {
+        inherit options pkgs;
+      };
+  };
 in {
   inherit
     removeAtPath
     removeNestedAttrs
     mkOptionsList
     mkOptionsListFromModules
+    hm
     ;
 }

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,0 +1,75 @@
+{lib}: let
+  parsePath = pathStr: lib.splitString "." pathStr;
+
+  removeNestedAttrs = paths: set: lib.foldl' (s: p: removeAtPath (parsePath p) s) set paths;
+
+  removeAtPath = path: set:
+    if path == []
+    then set
+    else let
+      key = builtins.head path;
+      rest = builtins.tail path;
+      sub = set.${key} or null;
+    in
+      if rest == []
+      then builtins.removeAttrs set [key]
+      else if builtins.isAttrs sub
+      then
+        set
+        // {
+          ${key} = removeAtPath rest sub;
+        }
+      else set;
+
+  /*
+  Create an options list JSON file from an options attribute set.
+
+  @param  options   options attribute set to generate options list from
+  @param  excluded  paths to options or sets of options to skip over
+  @return           a derivation that builds an options.json file
+  */
+  mkOptionsList = {
+    options,
+    pkgs,
+    excluded ? [],
+  }: let
+    options' = removeAtPath excluded options;
+
+    rawOptions =
+      lib.optionAttrSetToDocList options';
+    filteredOptions = lib.filter (opt: opt.visible && !opt.internal) rawOptions;
+
+    optionsJSON = builtins.unsafeDiscardStringContext (builtins.toJSON filteredOptions);
+  in
+    pkgs.writeText "options.json" optionsJSON;
+
+  /*
+  Create an options list JSON string from a list of modules.
+
+  @param  modules   list of modules containing options
+  @return           a derivation that builds an options.json file
+  */
+  mkOptionsListFromModules = {
+    modules,
+    pkgs,
+  }: let
+    eval'd = lib.evalModules {
+      modules =
+        modules
+        ++ [
+          {_module.check = false;}
+        ];
+    };
+  in
+    mkOptionsList {
+      inherit pkgs;
+      inherit (eval'd) options;
+    };
+in {
+  inherit
+    removeAtPath
+    removeNestedAttrs
+    mkOptionsList
+    mkOptionsListFromModules
+    ;
+}


### PR DESCRIPTION
This creates a little library in order to generate proper `options.json` files from `options` attribute sets, based on a stripped-down version of the `pkgs.nixosOptionsDoc` function.

Useful for shorthands for declaring an options file, especially when declared from a Nix file, so that users are not forced to create their own `lib.optionAttrSetFromDocList` invocations, and can instead generate options list files ahead of time inside Nix modules.

I'll create some modules for nix-darwin, NixOS, and home-manager systems to make this a bit more usable, and also document the usage of these functions on my website.