### PR TITLE
feat(module): add platform optnix modules

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,22 @@
-(
-  import
-  (
-    let
-      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-    in
-      fetchTarball {
-        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-        sha256 = lock.nodes.flake-compat.locked.narHash;
-      }
-  )
-  {src = ./.;}
-).defaultNix
+{pkgs ? import <nixpkgs> {}}: let
+  flakeSelf =
+    (
+      import
+      (
+        let
+          lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+        in
+          fetchTarball {
+            url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+            sha256 = lock.nodes.flake-compat.locked.narHash;
+          }
+      )
+      {src = ./.;}
+    ).outputs;
+in {
+  inherit (flakeSelf.packages.${pkgs.system}) optnix;
+
+  nixosModules.optnix = flakeSelf.nixosModules.optnix;
+  darwinModules.optnix = flakeSelf.darwinModules.optnix;
+  homeModules.optnix = flakeSelf.homeModules.optnix;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
       };
     });
 
+    nixosModules.optnix = import ./nix/modules/nixos.nix self;
     homeModules.optnix = import ./nix/modules/home-manager.nix self;
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -40,5 +40,7 @@
         ];
       };
     });
+
+    homeModules.optnix = import ./nix/modules/home-manager.nix self;
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
     });
 
     nixosModules.optnix = import ./nix/modules/nixos.nix self;
+    darwinModules.optnix = import ./nix/modules/nix-darwin.nix self;
     homeModules.optnix = import ./nix/modules/home-manager.nix self;
   };
 }

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -1,0 +1,36 @@
+self: {
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  cfg = config.programs.optnix;
+
+  tomlFormat = pkgs.formats.toml {};
+in {
+  options.programs.optnix = {
+    enable = lib.mkEnableOption "CLI searcher for Nix module system options";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "Package that provides optnix";
+      default = self.packages.${pkgs.system}.optnix;
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.attrs;
+      description = "Settings to put into optnix.toml";
+      default = {};
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [cfg.package];
+
+    xdg.configFile = {
+      "optnix/config.toml" = lib.mkIf (cfg.settings != {}) {
+        source = tomlFormat.generate "config.toml" cfg.settings;
+      };
+    };
+  };
+}

--- a/nix/modules/nix-darwin.nix
+++ b/nix/modules/nix-darwin.nix
@@ -1,0 +1,36 @@
+self: {
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  cfg = config.programs.optnix;
+
+  tomlFormat = pkgs.formats.toml {};
+in {
+  options.programs.optnix = {
+    enable = lib.mkEnableOption "CLI searcher for Nix module system options";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "Package that provides optnix";
+      default = self.packages.${pkgs.system}.optnix;
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.attrs;
+      description = "Settings to put into optnix.toml";
+      default = {};
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [cfg.package];
+
+    environment.etc = {
+      "optnix/config.toml" = lib.mkIf (cfg.settings != {}) {
+        source = tomlFormat.generate "config.toml" cfg.settings;
+      };
+    };
+  };
+}

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -1,0 +1,36 @@
+self: {
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  cfg = config.programs.optnix;
+
+  tomlFormat = pkgs.formats.toml {};
+in {
+  options.programs.optnix = {
+    enable = lib.mkEnableOption "CLI searcher for Nix module system options";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "Package that provides optnix";
+      default = self.packages.${pkgs.system}.optnix;
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.attrs;
+      description = "Settings to put into optnix.toml";
+      default = {};
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [cfg.package];
+
+    environment.etc = {
+      "optnix/config.toml" = lib.mkIf (cfg.settings != {}) {
+        source = tomlFormat.generate "config.toml" cfg.settings;
+      };
+    };
+  };
+}


### PR DESCRIPTION
This adds some basic modules for usage inside of NixOS, nix-darwin, and home-manager.

Usage and common recipes based on using the `optnixLib` attribute will be documented in a website soon.