### PR TITLE
fix(completion): improve scope completion mechanisms

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -63,8 +64,8 @@ func completeScopes(cmd *cobra.Command, args []string, toComplete string) ([]str
 	cfg := config.FromContext(cmd.Context())
 
 	scopes := []string{}
-	for name := range cfg.Scopes {
-		scopes = append(scopes, name)
+	for name, scope := range cfg.Scopes {
+		scopes = append(scopes, fmt.Sprintf("%s\t%s", name, scope.Description))
 	}
 
 	return scopes, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -127,6 +127,8 @@ func CreateCommand() *cobra.Command {
 				return nil
 			}
 
+			inCompletionMode := cmd.CalledAs() == cobra.ShellCompRequestCmd
+
 			configLocations := append(config.DefaultConfigLocations, opts.Config...)
 
 			cfg, err := config.ParseConfig(configLocations...)
@@ -135,12 +137,14 @@ func CreateCommand() *cobra.Command {
 				return err
 			}
 
-			if err := cfg.Validate(); err != nil {
-				return err
+			if !inCompletionMode {
+				if err := cfg.Validate(); err != nil {
+					return err
+				}
 			}
 
 			if opts.Scope == "" {
-				if cfg.DefaultScope == "" {
+				if cfg.DefaultScope == "" && !inCompletionMode {
 					return cmdUtils.ErrorWithHint{
 						Msg:  "no scope was provided and no default scope is set in the configuration",
 						Hint: "either set a default configuration or specify one with -s",


### PR DESCRIPTION
There were two big problems with the scope completions.

One: they would not trigger because of validations that were performed in `PersistentPreRunE`. To fix this, I have disabled configuration validation mechanisms while in completion mode.

Also, descriptions were not being utilized properly, so this adds descriptions to the generated completions.