### PR TITLE
ci: change update frequency to monthly

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     # Every Saturday at 0:00 UTC
-    - cron: '0 0 * * 6'
+    - cron: '0 0 1 * *'
 
 jobs:
   update-flake-inputs:


### PR DESCRIPTION
Weekly flake.lock updates are too frequent and clutter up history.