### PR TITLE
fix(tui): show more descriptive prompts when no options are discovered

### DIFF
--- a/tui/preview.go
+++ b/tui/preview.go
@@ -47,10 +47,7 @@ func (m PreviewModel) SetOption(opt *option.NixosOption) PreviewModel {
 	return m
 }
 
-var (
-	titleColor  = color.New(color.Bold)
-	italicColor = color.New(color.Italic)
-)
+var titleColor = color.New(color.Bold)
 
 func (m PreviewModel) Update(msg tea.Msg) (PreviewModel, tea.Cmd) {
 	switch msg := msg.(type) {
@@ -110,7 +107,7 @@ func (m PreviewModel) renderOptionView() string {
 	sb.WriteString("\n\n")
 
 	if m.option == nil {
-		sb.WriteString("No option selected.")
+		sb.WriteString("\n  No option selected.")
 		return sb.String()
 	}
 

--- a/tui/results.go
+++ b/tui/results.go
@@ -26,6 +26,7 @@ var (
 type ResultListModel struct {
 	options  option.NixosOptionSource
 	filtered []fuzzy.Match
+	input    string
 
 	focused bool
 
@@ -44,6 +45,11 @@ func NewResultListModel(options option.NixosOptionSource) ResultListModel {
 
 func (m ResultListModel) SetResultList(matches []fuzzy.Match) ResultListModel {
 	m.filtered = matches
+	return m
+}
+
+func (m ResultListModel) SetQuery(input string) ResultListModel {
+	m.input = input
 	return m
 }
 
@@ -193,7 +199,15 @@ func (m ResultListModel) View() string {
 
 		line := style.Width(m.width).MaxHeight(1).Render(b.String())
 		lines = append(lines, line)
+	}
 
+	if len(m.filtered) == 0 && len(lines) > 2 {
+		inputLen := len(m.input)
+		if inputLen > 3 {
+			lines[2] = "  No results found."
+		} else if inputLen > 0 {
+			lines[2] = "  Please provide more precise search terms."
+		}
 	}
 
 	body := strings.Join(lines, "\n")

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -193,6 +193,7 @@ func (m Model) runSearch(query string) Model {
 	slices.Reverse(m.filtered)
 
 	m.results = m.results.
+		SetQuery(query).
 		SetResultList(m.filtered).
 		SetSelectedIndex(len(m.filtered) - 1)
 


### PR DESCRIPTION
When an imprecise search term (either 1 or 2 characters) is typed and no results are found:

<img width="974" height="582" alt="2025-07-13_01-03-31" src="https://github.com/user-attachments/assets/03303fa8-846c-4b5c-a510-a65a963a08a4" />

When a larger search term results in no options found:

<img width="977" height="569" alt="2025-07-13_01-03-54" src="https://github.com/user-attachments/assets/f642fd7f-fde4-404e-8e52-63b2584b1aa5" />
