### PR TITLE
fix(tui): make esc key exit whole program in search mode

### DIFF
--- a/tui/tui.go
+++ b/tui/tui.go
@@ -115,6 +115,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "ctrl+c":
 			return m, tea.Quit
+		case "esc":
+			if m.mode != ViewModeEvalValue {
+				return m, tea.Quit
+			}
 		}
 	case tea.WindowSizeMsg:
 		m = m.updateWindowSize(msg.Width, msg.Height)


### PR DESCRIPTION
In most TUIs, `<Esc>` is an intuitive way to exit the program. This already works for other non-main view modes like the evaluation view.

This implements that keybind for the main search UI.

Closes #20.