### PR TITLE
fix(tui): replace external man call with embedding help text directly

### DIFF
--- a/option/printer.go
+++ b/option/printer.go
@@ -26,7 +26,7 @@ func (o *NixosOption) PrettyPrint(value *ValuePrinterInput) string {
 	if desc == "" {
 		desc = italicStyle.Sprint("(none)")
 	} else {
-		d, err := markdownRenderer.Render(desc)
+		d, err := renderer.Render(desc)
 		if err != nil {
 			desc = italicStyle.Sprintf("warning: failed to render description: %v\n", err) + desc
 		} else {
@@ -88,10 +88,10 @@ func (o *NixosOption) PrettyPrint(value *ValuePrinterInput) string {
 
 var (
 	markdownRenderIndentWidth uint = 0
-	markdownRenderer          *glamour.TermRenderer
+	renderer                       = NewMarkdownRenderer()
 )
 
-func init() {
+func NewMarkdownRenderer() *glamour.TermRenderer {
 	glamourStyles.DarkStyleConfig.Document.Margin = &markdownRenderIndentWidth
 
 	r, _ := glamour.NewTermRenderer(
@@ -99,7 +99,7 @@ func init() {
 		glamour.WithWordWrap(80),
 	)
 
-	markdownRenderer = r
+	return r
 }
 
 var annotationsToRemove = []string{

--- a/tui/help.go
+++ b/tui/help.go
@@ -1,0 +1,78 @@
+package tui
+
+import (
+	_ "embed"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/water-sucks/optnix/option"
+)
+
+//go:embed option_help.md
+var helpContent string
+
+func init() {
+	r := option.NewMarkdownRenderer()
+	rendered, err := r.Render(helpContent)
+	if err == nil {
+		helpContent = rendered
+	}
+}
+
+type HelpModel struct {
+	vp viewport.Model
+
+	width  int
+	height int
+}
+
+func NewHelpModel() HelpModel {
+	vp := viewport.New(0, 0)
+	vp.SetHorizontalStep(1)
+
+	vp.Style = focusedBorderStyle
+
+	return HelpModel{
+		vp: vp,
+	}
+}
+
+func (m HelpModel) Update(msg tea.Msg) (HelpModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "esc":
+			return m, func() tea.Msg {
+				return ChangeViewModeMsg(ViewModeSearch)
+			}
+		}
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width - 4
+		m.height = msg.Height - 4
+
+		m.vp.Width = m.width
+		m.vp.Height = m.height
+
+		m.vp.SetContent(m.constructHelpContent())
+
+		return m, nil
+	}
+
+	var cmd tea.Cmd
+	m.vp, cmd = m.vp.Update(msg)
+
+	return m, cmd
+}
+
+func (m HelpModel) View() string {
+	return m.vp.View()
+}
+
+func (m HelpModel) constructHelpContent() string {
+	title := lipgloss.PlaceHorizontal(m.width, lipgloss.Center, titleStyle.Render("Help"))
+	line := lipgloss.NewStyle().Width(m.width).Inherit(titleRuleStyle).Render("")
+
+	return title + "\n" + line + helpContent
+}

--- a/tui/option_help.md
+++ b/tui/option_help.md
@@ -1,0 +1,53 @@
+# Concepts
+
+This application consists of three views:
+
+- **Main View** :: Search and preview options
+- **Help View** :: Display this help page
+- **Value View** :: Show the current value of an option
+
+A **purple border** indicates the active (focused) view. Keybinds will only work
+in the context of the currently active view.
+
+To quit this application, press `Ctrl+C` or `Esc` from the main view.
+
+---
+
+## Main View
+
+The main view appears when the application starts. It contains two _windows_:
+
+- **Search Window** (left) :: User types to see available options
+- **Preview Window** (right) :: Displays info about the selected option
+
+Press `<Tab>` to switch focus between the two windows.
+
+Press `<Enter>` to view the current value of a selected option, if available;
+this will open the **value view**.
+
+### Search Window
+
+Type to filter the list of options.
+
+Use the `Up` + `Down` arrows to navigate the results. As you move through the
+list, the **Preview Window** updates automatically.
+
+### Preview Window
+
+Shows detailed information about the selected option.
+
+Use the arrow keys or `h`, `j`, `k`, and `l` to scroll around.
+
+## Value View
+
+Displays the current value of the selected option (if it can be evaluated).
+
+Use the arrow keys or `h`, `j`, `k`, and `l` to scroll around.
+
+Press `<Esc>` or `q` to close this window.
+
+## Help View
+
+Use the arrow keys or `h`, `j`, `k`, and `l` to scroll around.
+
+Press `<Esc>` or `q` to close this window.


### PR DESCRIPTION
The remnants of the old `nixos option -i` days, where this called out directly to a manpage named `nixos-cli-option-tui(5)`.

Alas, it does not exist anymore, and the help view has just been completely broken until now.

This uses a new model, the `HelpModel`, and makes it a new view mode. Instructions for usage are embedded and rendered using the glamour Markdown renderer, which is already used for rendering descriptions.