### PR TITLE
ci: add golangci-lint to prerequisites

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,8 +27,10 @@ jobs:
           skipPush: true
 
       - name: Check for compile errors
-        run: |
-          nix develop .# -c make
+        run: nix develop .# -c make
+
+      - name: Run checks
+        run: nix develop .# -c make check
 
       - name: Run tests
         run: nix develop .# -c make test

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,11 @@ clean:
 	go clean
 	rm -rf ./nixos site/ $(MANPAGES)
 
+.PHONY: check
+check:
+	@echo "running checks..."
+	golangci-lint run
+
 .PHONY: test
 test:
 	@echo "running tests..."


### PR DESCRIPTION
Pretty self-explanatory. Run `golangci-lint` on pull requests to ensure some extra static checks pass.