### PR TITLE
feat(tui): add Ctrl+Y to copy option name/value to clipboard

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module snare.dev/optnix
 go 1.24.2
 
 require (
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.5
 	github.com/charmbracelet/glamour v0.10.0
@@ -20,7 +21,6 @@ require (
 
 require (
 	github.com/alecthomas/chroma/v2 v2.18.0 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/colorprofile v0.3.1 // indirect

--- a/tui/option_help.md
+++ b/tui/option_help.md
@@ -26,6 +26,8 @@ Press `<Tab>` to switch focus between the two windows.
 Press `<Enter>` to view the current value of a selected option, if available;
 this will open the **value view**.
 
+Press `Ctrl+Y` to copy the selected option name to the clipboard.
+
 Press `Ctrl+O` to open the scope select view.
 
 Press `<Shift+Tab>` to cycle to the next scope.
@@ -53,6 +55,8 @@ Use the arrow keys or `h`, `j`, `k`, and `l` to scroll around.
 Displays the current value of the selected option (if it can be evaluated).
 
 Use the arrow keys or `h`, `j`, `k`, and `l` to scroll around.
+
+Press `Ctrl+Y` to copy the evaluated value to the clipboard.
 
 Press `<Esc>` or `q` to close this window.
 

--- a/tui/status_bar.go
+++ b/tui/status_bar.go
@@ -1,0 +1,55 @@
+package tui
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type StatusBarModel struct {
+	defaultText string
+	flashText   string
+	flashActive bool
+	flashID     int
+	width       int
+}
+
+func NewStatusBarModel() StatusBarModel {
+	return StatusBarModel{
+		defaultText: "For basic help, press Ctrl-G.",
+	}
+}
+
+func (m StatusBarModel) SetWidth(width int) StatusBarModel {
+	m.width = width
+	return m
+}
+
+func (m StatusBarModel) Update(msg tea.Msg) (StatusBarModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case CopiedToClipboardMsg:
+		m.flashActive = true
+		m.flashText = "Copied to clipboard!"
+		m.flashID++
+		id := m.flashID
+		return m, tea.Tick(2*time.Second, func(time.Time) tea.Msg {
+			return ClearClipboardFlashMsg{id: id}
+		})
+	case ClearClipboardFlashMsg:
+		if msg.id == m.flashID {
+			m.flashActive = false
+			m.flashText = ""
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m StatusBarModel) View() string {
+	text := m.defaultText
+	if m.flashActive {
+		text = m.flashText
+	}
+	return lipgloss.PlaceHorizontal(m.width, lipgloss.Center, hintStyle.Render(text))
+}

--- a/tui/status_bar.go
+++ b/tui/status_bar.go
@@ -9,9 +9,9 @@ import (
 
 type StatusBarModel struct {
 	defaultText string
-	flashText   string
-	flashActive bool
-	flashID     int
+	text        string
+	kind        NotificationKind
+	id          int
 	width       int
 }
 
@@ -28,18 +28,17 @@ func (m StatusBarModel) SetWidth(width int) StatusBarModel {
 
 func (m StatusBarModel) Update(msg tea.Msg) (StatusBarModel, tea.Cmd) {
 	switch msg := msg.(type) {
-	case CopiedToClipboardMsg:
-		m.flashActive = true
-		m.flashText = "Copied to clipboard!"
-		m.flashID++
-		id := m.flashID
+	case NotificationMsg:
+		m.text = msg.Message
+		m.kind = msg.Kind
+		m.id++
+		id := m.id
 		return m, tea.Tick(2*time.Second, func(time.Time) tea.Msg {
-			return ClearClipboardFlashMsg{id: id}
+			return ClearNotificationMsg{ID: id}
 		})
-	case ClearClipboardFlashMsg:
-		if msg.id == m.flashID {
-			m.flashActive = false
-			m.flashText = ""
+	case ClearNotificationMsg:
+		if msg.ID == m.id {
+			m.text = ""
 		}
 		return m, nil
 	}
@@ -47,9 +46,12 @@ func (m StatusBarModel) Update(msg tea.Msg) (StatusBarModel, tea.Cmd) {
 }
 
 func (m StatusBarModel) View() string {
-	text := m.defaultText
-	if m.flashActive {
-		text = m.flashText
+	text, style := m.defaultText, hintStyle
+	if m.text != "" {
+		text = m.text
+		if m.kind == NotificationError {
+			style = errorHintStyle
+		}
 	}
-	return lipgloss.PlaceHorizontal(m.width, lipgloss.Center, hintStyle.Render(text))
+	return lipgloss.PlaceHorizontal(m.width, lipgloss.Center, style.Render(text))
 }

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -31,10 +31,9 @@ var (
 			BorderBottom(false).
 			BorderLeft(false)
 
-	marginStyle = lipgloss.NewStyle().Margin(2, 2, 0, 2)
-	hintStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.ANSIColor(termenv.ANSIYellow))
-
+	marginStyle    = lipgloss.NewStyle().Margin(2, 2, 0, 2)
+	hintStyle      = lipgloss.NewStyle().Foreground(ansiYellow)
+	errorHintStyle = lipgloss.NewStyle().Foreground(ansiRed).Bold(true)
 )
 
 type Model struct {
@@ -71,8 +70,33 @@ const (
 
 type ChangeViewModeMsg ViewMode
 
-type CopiedToClipboardMsg struct{}
-type ClearClipboardFlashMsg struct{ id int }
+type NotificationKind int
+
+const (
+	NotificationNormal NotificationKind = iota
+	NotificationError
+)
+
+type NotificationMsg struct {
+	Message string
+	Kind    NotificationKind
+}
+
+type ClearNotificationMsg struct {
+	ID int
+}
+
+func copyToClipboardCmd(value string) tea.Cmd {
+	return func() tea.Msg {
+		if err := clipboard.WriteAll(value); err != nil {
+			return NotificationMsg{
+				Message: "Copy failed: " + err.Error(),
+				Kind:    NotificationError,
+			}
+		}
+		return NotificationMsg{Message: "Copied to clipboard!"}
+	}
+}
 
 type FocusArea int
 
@@ -172,7 +196,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		return m, nil
 
-	case CopiedToClipboardMsg, ClearClipboardFlashMsg:
+	case NotificationMsg, ClearNotificationMsg:
 		var cmd tea.Cmd
 		m.statusBar, cmd = m.statusBar.Update(msg)
 		return m, cmd
@@ -254,10 +278,7 @@ func (m Model) updateSearch(msg tea.Msg) (Model, tea.Cmd) {
 
 		case "ctrl+y":
 			if opt := m.results.GetSelectedOption(); opt != nil {
-				return m, func() tea.Msg {
-					clipboard.WriteAll(opt.Name)
-					return CopiedToClipboardMsg{}
-				}
+				return m, copyToClipboardCmd(opt.Name)
 			}
 		}
 	case RunSearchMsg:

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"time"
 	"unicode"
 
+	"github.com/atotto/clipboard"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
@@ -49,6 +51,8 @@ type Model struct {
 	width  int
 	height int
 
+	clipboardFlash bool
+
 	search      SearchBarModel
 	results     ResultListModel
 	preview     PreviewModel
@@ -67,6 +71,9 @@ const (
 )
 
 type ChangeViewModeMsg ViewMode
+
+type CopiedToClipboardMsg struct{}
+type ClearClipboardFlashMsg struct{}
 
 type FocusArea int
 
@@ -161,6 +168,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		return m, nil
 
+	case CopiedToClipboardMsg:
+		m.clipboardFlash = true
+		return m, tea.Tick(2*time.Second, func(time.Time) tea.Msg {
+			return ClearClipboardFlashMsg{}
+		})
+
+	case ClearClipboardFlashMsg:
+		m.clipboardFlash = false
+		return m, nil
+
 	case ChangeViewModeMsg:
 		m.mode = ViewMode(msg)
 
@@ -234,6 +251,14 @@ func (m Model) updateSearch(msg tea.Msg) (Model, tea.Cmd) {
 
 			return m, func() tea.Msg {
 				return ChangeViewModeMsg(ViewModeSelectScope)
+			}
+
+		case "ctrl+y":
+			if opt := m.results.GetSelectedOption(); opt != nil {
+				return m, func() tea.Msg {
+					clipboard.WriteAll(opt.Name)
+					return CopiedToClipboardMsg{}
+				}
 			}
 		}
 	case RunSearchMsg:
@@ -445,7 +470,11 @@ func (m Model) View() string {
 	left := lipgloss.JoinVertical(lipgloss.Top, results, search)
 	main := lipgloss.JoinHorizontal(lipgloss.Top, left, preview)
 
-	hint := lipgloss.PlaceHorizontal(m.width, lipgloss.Center, hintStyle.Render("For basic help, press Ctrl-G."))
+	hintText := "For basic help, press Ctrl-G."
+	if m.clipboardFlash {
+		hintText = "Copied to clipboard!"
+	}
+	hint := lipgloss.PlaceHorizontal(m.width, lipgloss.Center, hintStyle.Render(hintText))
 
 	return lipgloss.JoinVertical(
 		lipgloss.Top,

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
-	"time"
 	"unicode"
 
 	"github.com/atotto/clipboard"
@@ -33,8 +32,8 @@ var (
 			BorderLeft(false)
 
 	marginStyle = lipgloss.NewStyle().Margin(2, 2, 0, 2)
-	hintStyle   = lipgloss.NewStyle().
-			Foreground(lipgloss.ANSIColor(termenv.ANSIYellow)) // Soft gray
+	hintStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.ANSIColor(termenv.ANSIYellow))
 
 )
 
@@ -51,7 +50,7 @@ type Model struct {
 	width  int
 	height int
 
-	clipboardFlash bool
+	statusBar StatusBarModel
 
 	search      SearchBarModel
 	results     ResultListModel
@@ -73,7 +72,7 @@ const (
 type ChangeViewModeMsg ViewMode
 
 type CopiedToClipboardMsg struct{}
-type ClearClipboardFlashMsg struct{}
+type ClearClipboardFlashMsg struct{ id int }
 
 type FocusArea int
 
@@ -131,6 +130,7 @@ func NewModel(
 		selectScope: selectScope,
 		eval:        eval,
 		help:        help,
+		statusBar:   NewStatusBarModel(),
 	}, nil
 }
 
@@ -161,22 +161,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m = m.updateWindowSize(msg.Width, msg.Height)
 
+		m.statusBar = m.statusBar.SetWidth(msg.Width)
+
 		// Always forward resize events to components that need them.
-		m.eval, _ = m.eval.Update(msg)
-		m.help, _ = m.help.Update(msg)
-		m.selectScope, _ = m.selectScope.Update(msg)
+		// Shrink height by 1 so overlays leave room for the status bar.
+		overlayMsg := tea.WindowSizeMsg{Width: msg.Width, Height: msg.Height - 1}
+		m.eval, _ = m.eval.Update(overlayMsg)
+		m.help, _ = m.help.Update(overlayMsg)
+		m.selectScope, _ = m.selectScope.Update(overlayMsg)
 
 		return m, nil
 
-	case CopiedToClipboardMsg:
-		m.clipboardFlash = true
-		return m, tea.Tick(2*time.Second, func(time.Time) tea.Msg {
-			return ClearClipboardFlashMsg{}
-		})
-
-	case ClearClipboardFlashMsg:
-		m.clipboardFlash = false
-		return m, nil
+	case CopiedToClipboardMsg, ClearClipboardFlashMsg:
+		var cmd tea.Cmd
+		m.statusBar, cmd = m.statusBar.Update(msg)
+		return m, cmd
 
 	case ChangeViewModeMsg:
 		m.mode = ViewMode(msg)
@@ -432,7 +431,7 @@ func (m Model) updateWindowSize(width, height int) Model {
 	m.height = height
 
 	usableWidth := width - 4   // 2 left + 2 right margins
-	usableHeight := height - 2 // 2 top margin
+	usableHeight := height - 3 // 2 top margin + 1 status bar
 
 	searchHeight := 3
 
@@ -454,33 +453,26 @@ func (m Model) updateWindowSize(width, height int) Model {
 }
 
 func (m Model) View() string {
+	var content string
+
 	switch m.mode {
 	case ViewModeSelectScope:
-		return marginStyle.Render(m.selectScope.View())
+		content = marginStyle.Render(m.selectScope.View())
 	case ViewModeEvalValue:
-		return marginStyle.Render(m.eval.View())
+		content = marginStyle.Render(m.eval.View())
 	case ViewModeHelp:
-		return marginStyle.Render(m.help.View())
+		content = marginStyle.Render(m.help.View())
+	default:
+		results := m.results.View()
+		search := m.search.View()
+		preview := m.preview.View()
+
+		left := lipgloss.JoinVertical(lipgloss.Top, results, search)
+		main := lipgloss.JoinHorizontal(lipgloss.Top, left, preview)
+		content = marginStyle.Render(main)
 	}
 
-	results := m.results.View()
-	search := m.search.View()
-	preview := m.preview.View()
-
-	left := lipgloss.JoinVertical(lipgloss.Top, results, search)
-	main := lipgloss.JoinHorizontal(lipgloss.Top, left, preview)
-
-	hintText := "For basic help, press Ctrl-G."
-	if m.clipboardFlash {
-		hintText = "Copied to clipboard!"
-	}
-	hint := lipgloss.PlaceHorizontal(m.width, lipgloss.Center, hintStyle.Render(hintText))
-
-	return lipgloss.JoinVertical(
-		lipgloss.Top,
-		marginStyle.Render(main),
-		hint,
-	)
+	return lipgloss.JoinVertical(lipgloss.Top, content, m.statusBar.View())
 }
 
 type OptionTUIArgs struct {

--- a/tui/value.go
+++ b/tui/value.go
@@ -1,7 +1,6 @@
 package tui
 
 import (
-	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -67,10 +66,7 @@ func (m EvalValueModel) Update(msg tea.Msg) (EvalValueModel, tea.Cmd) {
 			}
 		case "ctrl+y":
 			if m.evaluated != "" && !m.loading {
-				return m, func() tea.Msg {
-					clipboard.WriteAll(m.evaluated)
-					return CopiedToClipboardMsg{}
-				}
+				return m, copyToClipboardCmd(m.evaluated)
 			}
 		}
 

--- a/tui/value.go
+++ b/tui/value.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -63,6 +64,13 @@ func (m EvalValueModel) Update(msg tea.Msg) (EvalValueModel, tea.Cmd) {
 		case "q", "esc":
 			return m, func() tea.Msg {
 				return ChangeViewModeMsg(ViewModeSearch)
+			}
+		case "ctrl+y":
+			if m.evaluated != "" && !m.loading {
+				return m, func() tea.Msg {
+					clipboard.WriteAll(m.evaluated)
+					return CopiedToClipboardMsg{}
+				}
 			}
 		}
 


### PR DESCRIPTION
Use Ctrl+Y in the main search view to copy the selected option name,
or in the value view to copy the evaluated value. Shows a brief
"Copied to clipboard!" flash in the hint bar.
